### PR TITLE
Revert "[Melodic] Ignore moveit_experimental"

### DIFF
--- a/melodic.ignored
+++ b/melodic.ignored
@@ -1,1 +1,0 @@
-moveit_experimental


### PR DESCRIPTION
To solve https://github.com/ros-planning/moveit/issues/1225#issuecomment-445876179, the simplest is to just release an empty moveit-experimental package.